### PR TITLE
Add workflow_dispatch trigger to workflows

### DIFF
--- a/.github/workflows/anchore.yml
+++ b/.github/workflows/anchore.yml
@@ -7,6 +7,7 @@
 name: Anchore Container Scan
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 6 * * 1'
   push:


### PR DESCRIPTION
## Summary

Adds a `workflow_dispatch` trigger to both GitHub Actions workflows so they can be run manually from the Actions tab in the GitHub UI.

- **`docker.yml`** (Docker build/push) — previously only ran on schedule and push to `master`
- **`anchore.yml`** (Anchore Container Scan) — previously only ran on push/PR to `master` and schedule

## Why

Manual triggering is useful for re-running the Docker build (e.g. to pick up upstream base image updates) or the security scan on demand, without waiting for the weekly cron or pushing a commit.

https://claude.ai/code/session_01YDL1TGTyUBpnLaQ2SZxwxV

---
_Generated by [Claude Code](https://claude.ai/code/session_01YDL1TGTyUBpnLaQ2SZxwxV)_